### PR TITLE
Fix GpuTools(Cuda(NoBinaryForGpu)) error

### DIFF
--- a/ec-gpu-gen/src/source.rs
+++ b/ec-gpu-gen/src/source.rs
@@ -618,10 +618,11 @@ fn generate_cuda(source_builder: &SourceBuilder) -> PathBuf {
                 // Compile with as many threads as CPUs are available.
                 .arg("--threads=0")
                 .arg("--fatbin")
-                .arg("--gpu-architecture=sm_86")
-                .arg("--generate-code=arch=compute_86,code=sm_86")
+                .arg("--gpu-architecture=sm_70")
+                .arg("--generate-code=arch=compute_70,code=sm_70")
+                .arg("--generate-code=arch=compute_72,code=sm_72")
                 .arg("--generate-code=arch=compute_80,code=sm_80")
-                .arg("--generate-code=arch=compute_75,code=sm_75");
+                .arg("--generate-code=arch=compute_86,code=sm_86");
             command
         }
     };


### PR DESCRIPTION
**Problem**: 

Trying to run zkWasm on V100 GPU with --feature cuda, and got the following error ```thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: GpuTools(Cuda(NoBinaryForGpu))', /home/ubuntu/.cargo/git/checkouts/halo2-gpu-specific-4d08aed75011eb52/64ccffd/halo2_proofs/src/arithmetic.rs:356:53```

**Solution**:

This issue was due to V100's GPU architecture is a bit older than RTX3090. When compiling with nvcc in ec-gpu-gen, we can add more version support for different architectures.

**Reference**: 

- _The issue was mentioned here https://github.com/filecoin-project/rust-gpu-tools/issues/79_
- _Find Matching CUDA arch and CUDA gencode for various NVIDIA architectures [here](https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/)_



